### PR TITLE
zephyr: Port liblc3 to Zephyr as external module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: liblc3codec
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
Add Zephyr module definition so that the project can be used as Zephyr
external module.

Fixes: https://github.com/zephyrproject-rtos/liblc3codec/issues/10
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>