### PR TITLE
zephyr: Rename it to use the repo name, liblc3

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,4 @@
-name: liblc3codec
+name: liblc3
 build:
   cmake-ext: True
   kconfig-ext: True


### PR DESCRIPTION
This was using an older name, rename to use the current one, aligned with the project.

Additional info https://github.com/zephyrproject-rtos/zephyr/pull/49346.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>