### PR TITLE
tools/elc3: Use correct offset for pcm buffer padding

### DIFF
--- a/tools/elc3.c
+++ b/tools/elc3.c
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
 
         int nread = wave_read_pcm(fp_in, pcm_sbytes, nch, frame_samples, pcm);
 
-        memset(pcm + nread * nch, 0,
+        memset(pcm + nread * nch * pcm_sbytes, 0,
             nch * (frame_samples - nread) * pcm_sbytes);
 
         if (floorf(i * frame_us * 1e-6) > nsec) {


### PR DESCRIPTION
The address offset of the pcm buffer computed is in samples instead of bytes. This causes the last few bytes of the original pcm content to get corrupted with the padding bytes.
Pass the number of bytes read instead of samples
as the address offset.