### PR TITLE
fix: compilation with older gcc versions

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -71,7 +71,7 @@
 #define LC3_ABS(v)  ( (v) < 0 ? -(v) : (v) )
 
 
-#ifdef __ARM_FEATURE_SAT
+#if defined(__ARM_FEATURE_SAT) && !(__GNUC__ < 10)
 
 #undef  LC3_SAT16
 #define LC3_SAT16(v) __ssat(v, 16)

--- a/src/ltpf_arm.h
+++ b/src/ltpf_arm.h
@@ -16,7 +16,7 @@
  *
  ******************************************************************************/
 
-#if __ARM_FEATURE_SIMD32 || defined(TEST_ARM)
+#if (__ARM_FEATURE_SIMD32 && !(__GNUC__ < 10) || defined(TEST_ARM))
 
 #ifndef TEST_ARM
 


### PR DESCRIPTION
The used intrinsics are not available on older versions of GCC, e.g. on GCC 9. The PR adds an explicit check for GCC Version. If there's a direct test for the used intrinsic, that might be better though.