### PR TITLE
meson: declare liblc3 as dependency

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -44,3 +44,12 @@ pkg_mod.generate(libraries : lc3lib,
                  name : 'liblc3',
                  filebase : 'lc3',
                  description : 'LC3 codec library')
+
+#Declare dependency
+liblc3_dep = declare_dependency(
+	link_with : lc3lib,
+	include_directories : inc)
+
+if meson.version().version_compare('>= 0.54.0')
+	meson.override_dependency('liblc3', liblc3_dep)
+endif


### PR DESCRIPTION
helps to compile liblc3 from source as a meson subproject if it is not installed as a system package

(https://mesonbuild.com/Dependencies.html#building-dependencies-as-subprojects)

Updated meson version to 0.54 since `meson.override_dependency` is introduced in version 0.54.0