### PR TITLE
Cast uint8_t value to unsigned before doing bit shift

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -322,7 +322,7 @@ static inline void accu_load(struct lc3_bits_accu *accu,
 
     for ( ; nbytes; nbytes--) {
         accu->v >>= 8;
-        accu->v |= *(--buffer->p_bw) << (LC3_ACCU_BITS - 8);
+        accu->v |= (unsigned)*(--buffer->p_bw) << (LC3_ACCU_BITS - 8);
     }
 
     if (accu->n >= 8) {


### PR DESCRIPTION
Cast uint8_t value to unsigned before doing bit shift. The `p_bw` is a uint8_t*, so deref of that is uint8_t, and then shifting that by 24 is undefined behavior. It seems likely that the intent was to cast the one byte being loaded via the dereference to the same type as `accu->v`, which is `unsigned` type before the `<<`.
