### PR TITLE
python bindings: build/install via integrated meson support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ $ cd build && meson install
 A python wrapper, installed as follows, is available in the `python` directory.
 
 ```sh
-$ python3 -m pip install ./python
+$ python3 -m pip install .
 ```
 
 Decoding and encoding tools are provided in `python/tools`, like C tools,

--- a/meson.build
+++ b/meson.build
@@ -32,3 +32,7 @@ subdir('src')
 if get_option('tools')
     subdir('tools')
 endif
+
+if get_option('python')
+    subdir('python')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,3 +16,8 @@ option('tools',
     type: 'boolean',
     value: false,
     description: 'Build tools')
+
+option('python',
+    type: 'boolean',
+    value: false,
+    description: 'Build python bindings')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["meson-python"]
+build-backend = "mesonpy"
 
 [project]
 name = "lc3"
 version = "0.0.1"
-license = "Apache-2.0"
+license = { text="Apache-2.0" }
 authors = [
   { name="Antoine Soulier", email="asoulier@google.com" },
 ]
@@ -14,3 +14,6 @@ requires-python = ">=3.10"
 
 [project.urls]
 Homepage = "https://github.com/google/liblc3"
+
+[tool.meson-python.args]
+setup = ['-Dpython=true']

--- a/python/lc3.py
+++ b/python/lc3.py
@@ -17,6 +17,8 @@
 import array
 import ctypes
 import enum
+import glob
+import os
 
 from ctypes import c_bool, c_byte, c_int, c_uint, c_size_t, c_void_p
 from ctypes.util import find_library
@@ -55,7 +57,12 @@ class _Base:
             raise ValueError("Invalid sample rate: %d Hz" % samplerate)
 
         if libpath is None:
-            libpath = find_library("lc3")
+            mesonpy_lib = glob.glob(os.path.join(os.path.dirname(__file__), '.lc3.mesonpy.libs', '*lc3*'))
+
+            if mesonpy_lib:
+                libpath = mesonpy_lib[0]
+            else:
+                libpath = find_library("lc3")
             if not libpath:
                 raise Exception("LC3 library not found")
 

--- a/python/meson.build
+++ b/python/meson.build
@@ -1,0 +1,3 @@
+py = import('python').find_installation()
+
+py.install_sources('lc3.py')


### PR DESCRIPTION
The meson build system has builtin support for python packaging, and unlike hatchling it is spec-compliant. Additionally, meson is already responsible for building the shared library itself, which the python build backend can then distribute inside the wheel. This allows shipping a wheel that can find its own liblc3.so via ctypes and doesn't require passing paths to the library around, nor to install both separately and hope that this works.