### PR TITLE
build: fix rpath issue

### DIFF
--- a/tools/meson.build
+++ b/tools/meson.build
@@ -24,9 +24,11 @@ lc3toolslib = static_library('lc3toolslib',
 executable('elc3', ['elc3.c'],
     link_with : lc3toolslib,
     include_directories: inc,
-    install: true)
+    install: true,
+    install_rpath: join_paths(get_option('prefix'), get_option('libdir')))
 
 executable('dlc3', ['dlc3.c'],
     link_with : lc3toolslib,
     include_directories: inc,
-    install: true)
+    install: true,
+    install_rpath: join_paths(get_option('prefix'), get_option('libdir')))


### PR DESCRIPTION
While packaging for homebrew, I ran into some rpath issue when building the tools.

```
$ /opt/homebrew/Cellar/liblc3/1.1.0/bin/elc3 -h
dyld[72986]: Library not loaded: @rpath/liblc3.1.dylib
  Referenced from: <1B4E9174-0A9C-3907-8487-40BBBE5B52CB> /opt/homebrew/Cellar/liblc3/1.1.0/bin/elc3
  Reason: no LC_RPATH's found
Abort trap: 6
```

This patch is for fixing the rpath ref issue.