### PR TITLE
python: remove semicolons

### DIFF
--- a/tables/fastmath.py
+++ b/tables/fastmath.py
@@ -102,11 +102,11 @@ def approx_log2():
 
 def table_db_q16():
 
-    k = 10 * np.log10(2);
+    k = 10 * np.log10(2)
 
     for i in range(32):
-        a = k * np.log2(np.ldexp(32 + i  , -5)) - (i // 16) * (k/2);
-        b = k * np.log2(np.ldexp(32 + i+1, -5)) - (i // 16) * (k/2);
+        a = k * np.log2(np.ldexp(32 + i  , -5)) - (i // 16) * (k/2)
+        b = k * np.log2(np.ldexp(32 + i+1, -5)) - (i // 16) * (k/2)
 
         an = np.ldexp(a, 15) + 0.5
         bn = np.ldexp(b - a, 15) + 0.5

--- a/test/bitstream.py
+++ b/test/bitstream.py
@@ -164,7 +164,7 @@ class BitstreamWriter(Bitstream):
         self.low &= 0xffffff
         self.range = r * sym_freq
         while self.range < 0x10000:
-            self.range <<= 8;
+            self.range <<= 8
             self.ac_shift()
 
     def get_bits_left(self):
@@ -188,8 +188,8 @@ class BitstreamWriter(Bitstream):
         while self.range >> (24 - bits) == 0:
             bits += 1
 
-        mask = 0xffffff >> bits;
-        val = self.low + mask;
+        mask = 0xffffff >> bits
+        val = self.low + mask
 
         over1 = val >> 24
         val &= 0x00ffffff
@@ -212,7 +212,7 @@ class BitstreamWriter(Bitstream):
         while bits > 0:
             self.ac_shift()
             bits -= 8
-        bits += 8;
+        bits += 8
 
         val = self.cache
 
@@ -227,7 +227,7 @@ class BitstreamWriter(Bitstream):
 
             val = 0xff >> (8 - bits)
 
-        mask = 0x80;
+        mask = 0x80
         for k in range(bits):
 
             if val & mask == 0:

--- a/test/energy.py
+++ b/test/energy.py
@@ -53,7 +53,7 @@ def check_unit(rng, dt, sr):
     (e_c, nn_c) = lc3.energy_compute(dt, sr, x)
     ok = ok and np.amax(np.abs(e_c - e)) < 1e-5 and nn_c == nn
 
-    x[15*ns//16:] *= 1e2;
+    x[15*ns//16:] *= 1e2
 
     (e  , nn  ) = nrg.compute(x)
     (e_c, nn_c) = lc3.energy_compute(dt, sr, x)

--- a/test/spec.py
+++ b/test/spec.py
@@ -189,7 +189,7 @@ class SpectrumAnalysis(SpectrumQuantization):
             lev = 0
             while max(a, b) >= 4:
                 nbits_est += \
-                    T.AC_SPEC_BITS[T.AC_SPEC_LOOKUP[t + lev*1024]][16];
+                    T.AC_SPEC_BITS[T.AC_SPEC_LOOKUP[t + lev*1024]][16]
                 if lev == 0 and mode == 1:
                     nbits_lsb += 2
                 else:
@@ -206,20 +206,20 @@ class SpectrumAnalysis(SpectrumQuantization):
             b_lsb = abs(x[n+1])
             nbits_est += (min(a_lsb, 1) + min(b_lsb, 1)) * 2048
             if lev > 0 and mode == 1:
-                a_lsb >>= 1;
-                b_lsb >>= 1;
+                a_lsb >>= 1
+                b_lsb >>= 1
                 nbits_lsb += int(a_lsb == 0 and x[n  ] != 0)
                 nbits_lsb += int(b_lsb == 0 and x[n+1] != 0)
 
             if (x[n] != 0 or x[n+1] != 0) and \
                     (nbits_est <= nbits_spec * 2048):
-                lastnz_trunc = n + 2;
+                lastnz_trunc = n + 2
                 nbits_trunc = nbits_est
 
-            t = 1 + (a + b) * (lev + 1) if lev <= 1 else 12 + lev;
-            c = (c & 15) * 16 + t;
+            t = 1 + (a + b) * (lev + 1) if lev <= 1 else 12 + lev
+            c = (c & 15) * 16 + t
 
-        nbits_est = (nbits_est + 2047) // 2048 + nbits_lsb;
+        nbits_est = (nbits_est + 2047) // 2048 + nbits_lsb
         nbits_trunc = (nbits_trunc + 2047) // 2048
 
         self.rate = rate
@@ -248,7 +248,7 @@ class SpectrumAnalysis(SpectrumQuantization):
             delta = nbits / 48
 
         else:
-            delta = T3[sr] / 48;
+            delta = T3[sr] / 48
 
         delta = np.fix(delta + 0.5).astype(int)
 
@@ -257,7 +257,7 @@ class SpectrumAnalysis(SpectrumQuantization):
 
             factor = [ 3 + (nbits >= 520), 2, 0, 1 ][dt]
             g_incr = int(factor * (1 + (nbits - nbits_spec) / delta))
-            return min(g_idx + g_incr, 255) - g_idx;
+            return min(g_idx + g_incr, 255) - g_idx
 
         elif self.sr < T.SRATE_48K_HR and \
             ( (g_idx < 255 and nbits > nbits_spec) or \
@@ -418,8 +418,8 @@ class SpectrumAnalysis(SpectrumQuantization):
             if b_lsb > 0:
                 bits.write_bit(int(x[n+1] < 0))
 
-            t = 1 + (a + b) * (lev + 1) if lev <= 1 else 12 + lev;
-            c = (c & 15) * 16 + t;
+            t = 1 + (a + b) * (lev + 1) if lev <= 1 else 12 + lev
+            c = (c & 15) * 16 + t
 
         ### Residual data
 
@@ -531,8 +531,8 @@ class SpectrumSynthesis(SpectrumQuantization):
                 x[n+1] = -x[n+1]
 
             lev = min(lev, 3)
-            t = 1 + (a + b) * (lev + 1) if lev <= 1 else 12 + lev;
-            c = (c & 15) * 16 + t;
+            t = 1 + (a + b) * (lev + 1) if lev <= 1 else 12 + lev
+            c = (c & 15) * 16 + t
 
         ### Residual data
 

--- a/test/tns.py
+++ b/test/tns.py
@@ -300,8 +300,8 @@ class TnsSynthesis(Tns):
             xi = x[i] - rc[rc_order-1] * st[rc_order-1]
             for k in range(rc_order-2, -1, -1):
                 xi -= rc[k] * st[k]
-                st[k+1] = xi * rc[k] + st[k];
-            st[0] = xi;
+                st[k+1] = xi * rc[k] + st[k]
+            st[0] = xi
 
             y[i] = xi
 


### PR DESCRIPTION
While mostly harmless, random semicolons in Python can be a bit distracting when reading the code, especially when one uses a syntax highlighter that flags them as errors.