### PR TITLE
feature: Add lc3_encoder_disable_ltpf

### DIFF
--- a/include/lc3.h
+++ b/include/lc3.h
@@ -356,6 +356,17 @@ LC3_EXPORT lc3_encoder_t lc3_setup_encoder(
     int dt_us, int sr_hz, int sr_pcm_hz, void *mem);
 
 /**
+ * Disable LTPF analysis
+ * encoder        Handle of the encoder
+ *
+ * LTPF analysis is known to take a lot of CPU time and work quite bad on
+ * synthetic signals such as sine waves, so it might be beneficial to
+ * disable it in such cases.
+ */
+LC3_EXPORT void lc3_encoder_disable_ltpf(
+    lc3_encoder_t encoder);
+
+/**
  * Encode a frame
  * encoder         Handle of the encoder
  * fmt             PCM input format

--- a/include/lc3_cpp.h
+++ b/include/lc3_cpp.h
@@ -137,6 +137,11 @@ class Encoder : public Base<struct lc3_encoder> {
     }
   }
 
+  void DisableLTPF() {
+    for (auto &s : states)
+      lc3_encoder_disable_ltpf(s.get());
+  }
+
   ~Encoder() override = default;
 
   // Reset encoder state

--- a/include/lc3_private.h
+++ b/include/lc3_private.h
@@ -113,6 +113,8 @@ typedef struct lc3_spec_analysis {
 } lc3_spec_analysis_t;
 
 struct lc3_encoder {
+    bool ltpf_bypass;
+
     enum lc3_dt dt;
     enum lc3_srate sr, sr_pcm;
 

--- a/src/lc3.c
+++ b/src/lc3.c
@@ -301,7 +301,7 @@ static void analyze(struct lc3_encoder *encoder,
 
     bool att = lc3_attdet_run(dt, sr_pcm, nbytes, &encoder->attdet, xt);
 
-    side->pitch_present =
+    side->pitch_present = !encoder->ltpf_bypass &&
         lc3_ltpf_analyse(dt, sr_pcm, &encoder->ltpf, xt, &side->ltpf);
 
     memmove(xt - nt, xt + (ns-nt), nt * sizeof(*xt));
@@ -313,7 +313,7 @@ static void analyze(struct lc3_encoder *encoder,
     lc3_mdct_forward(dt, sr_pcm, sr, xs, xd, xf);
 
     bool nn_flag = lc3_energy_compute(dt, sr, xf, e);
-    if (nn_flag)
+    if (nn_flag || encoder->ltpf_bypass)
         lc3_ltpf_disable(&side->ltpf);
 
     side->bw = lc3_bwdet_run(dt, sr, e);
@@ -422,6 +422,12 @@ LC3_EXPORT struct lc3_encoder *lc3_setup_encoder(
     int dt_us, int sr_hz, int sr_pcm_hz, void *mem)
 {
     return lc3_hr_setup_encoder(false, dt_us, sr_hz, sr_pcm_hz, mem);
+}
+
+LC3_EXPORT void lc3_encoder_disable_ltpf(
+    struct lc3_encoder *encoder)
+{
+    encoder->ltpf_bypass = true;
 }
 
 /**

--- a/src/lc3.c
+++ b/src/lc3.c
@@ -122,7 +122,7 @@ LC3_EXPORT int lc3_hr_frame_block_bytes(
         nchannels * lc3_max_frame_bytes(dt, sr) );
 }
 
-LC3_EXPORT int lc3_frame_bock_bytes(int dt_us, int nchannels, int bitrate)
+LC3_EXPORT int lc3_frame_block_bytes(int dt_us, int nchannels, int bitrate)
 {
     return lc3_hr_frame_block_bytes(false, dt_us, 8000, nchannels, bitrate);
 }


### PR DESCRIPTION
LTPF requires a lot of processing power, so disabling might be required for embedded low-performance devices