### PR TITLE
Fix Clang warnings

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -139,7 +139,7 @@ int lc3_check_bits(const struct lc3_bits *bits)
 static inline void accu_flush(
     struct lc3_bits_accu *accu, struct lc3_bits_buffer *buffer)
 {
-    int nbytes = LC3_MIN(accu->n >> 3,
+    int nbytes = (int) LC3_MIN(accu->n >> 3,
         LC3_MAX(buffer->p_bw - buffer->p_fw, 0));
 
     accu->n -= 8 * nbytes;
@@ -249,7 +249,7 @@ void lc3_flush_bits(struct lc3_bits *bits)
     struct lc3_bits_accu *accu = &bits->accu;
     struct lc3_bits_buffer *buffer = &bits->buffer;
 
-    int nleft = buffer->p_bw - buffer->p_fw;
+    int nleft = (int)(buffer->p_bw - buffer->p_fw);
     for (int n = 8 * nleft - accu->n; n > 0; n -= 32)
         lc3_put_bits(bits, 0, LC3_MIN(n, 32));
 
@@ -316,7 +316,7 @@ static inline int ac_get(struct lc3_bits_buffer *buffer)
 static inline void accu_load(struct lc3_bits_accu *accu,
     struct lc3_bits_buffer *buffer)
 {
-    int nbytes = LC3_MIN(accu->n >> 3, buffer->p_bw - buffer->start);
+    int nbytes = (int)LC3_MIN(accu->n >> 3, buffer->p_bw - buffer->start);
 
     accu->n -= 8 * nbytes;
 

--- a/src/lc3.c
+++ b/src/lc3.c
@@ -150,7 +150,7 @@ LC3_EXPORT int lc3_hr_resolve_bitrate(
     if (dt >= LC3_NUM_DT || sr >= LC3_NUM_SRATE || nbytes < 0)
         return -1;
 
-    return LC3_MIN(((int64_t)nbytes * 3200 + dt) / (1 + dt), INT_MAX);
+    return (int) LC3_MIN(((int64_t)nbytes * 3200 + dt) / (1 + dt), INT_MAX);
 }
 
 LC3_EXPORT int lc3_resolve_bitrate(int dt_us, int nbytes)

--- a/src/ltpf.c
+++ b/src/ltpf.c
@@ -189,7 +189,7 @@ LC3_HOT static inline int32_t filter_hp50(
     const int32_t a1 = -2110217691, a2 = 1037111617;
     const int32_t b1 = -2110535566, b2 = 1055267782;
 
-    yn       = (hp50->s1 + (int64_t)xn * b2) >> 30;
+    yn       = (int32_t)((hp50->s1 + (int64_t)xn * b2) >> 30);
     hp50->s1 = (hp50->s2 + (int64_t)xn * b1 - (int64_t)yn * a1);
     hp50->s2 = (           (int64_t)xn * b2 - (int64_t)yn * a2);
 

--- a/src/ltpf_neon.h
+++ b/src/ltpf_neon.h
@@ -192,6 +192,12 @@ LC3_HOT static void neon_resample_48k_12k8(
  */
 #ifndef dot
 
+//
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconversion"
+#endif
+
 LC3_HOT static inline float neon_dot(const int16_t *a, const int16_t *b, int n)
 {
     int64x2_t v = vmovq_n_s64(0);
@@ -208,9 +214,24 @@ LC3_HOT static inline float neon_dot(const int16_t *a, const int16_t *b, int n)
         v = vpadalq_s32(v, u);
     }
 
-    int32_t v32 = (vaddvq_s64(v) + (1 << 5)) >> 6;
+    // Stepwise accumulation to avoid narrowing warnings
+
+    // Accumulate 64-bit sum
+    int64_t acc = vaddvq_s64(v);
+
+    // Add rounding offset and shift
+    acc += (1LL << 5);
+    acc >>= 6;
+
+    // Explicit cast to int32_t
+    int32_t v32 = (int32_t)acc;
+
     return (float)v32;
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #ifndef TEST_NEON
 #define dot neon_dot

--- a/src/tns.c
+++ b/src/tns.c
@@ -134,7 +134,7 @@ LC3_HOT static void compute_lpc_coeffs(
             xs = xe, xe = x + *(++sub);
 
             for (int k = 0; k <= maxorder; k++)
-                c[k][s] = dot(xs, xs + k, (xe - xs) - k);
+                c[k][s] = dot(xs, xs + k, (int)((xe - xs) - k));
         }
 
         r[f][0] = nsubdivisions;


### PR DESCRIPTION
I've run into a few "narrowing" issues trying to compile the lib with default settings and got a few errors.

The warnings for ptrdiff_t and int64_t to int32_t are straight forward. 

ChatGPT helped me to get Clang to compile ltpf_neon.h without warning/error, but it still requires #pragma diagnostic ignored "-Wconversion" even after splitting the calculation for v32 into simple and verifiable steps.

As a quick compile setup, you could checkout the master branch of BTstack (https://github.com/bluekitchen/btstack/), go to port/libusb, create an xcode folder and run `cmake .. -G Xcode`, then open the project and try to compile.