### PR TITLE
lc3: setup_decoder: allow downsampling from source

### DIFF
--- a/src/lc3.c
+++ b/src/lc3.c
@@ -702,7 +702,7 @@ LC3_EXPORT struct lc3_decoder *lc3_hr_setup_decoder(
     enum lc3_srate sr = resolve_srate(sr_hz, hrmode);
     enum lc3_srate sr_pcm = resolve_srate(sr_pcm_hz, hrmode);
 
-    if (dt >= LC3_NUM_DT || sr_pcm >= LC3_NUM_SRATE || sr > sr_pcm || !mem)
+    if (dt >= LC3_NUM_DT || sr_pcm >= LC3_NUM_SRATE || sr < sr_pcm || !mem)
         return NULL;
 
     struct lc3_decoder *decoder = mem;


### PR DESCRIPTION
There appears to be a bug where downsampling from received data `sr_hz` to pcm data `sr_pcm_hz` is disallowed for the decoder, which causes the setup to fail.

The encoder, on the other hand, sources the data from pcm, and allows downsampling from that to the other end.

Assuming symmetry w.r.t. the direction of downsampling, the comparison operator should be flipped.