### PR TITLE
bits: replace per-probe multiplies with one division in lc3_get_symbol

### DIFF
--- a/src/bits.h
+++ b/src/bits.h
@@ -289,12 +289,20 @@ LC3_HOT static inline unsigned lc3_get_symbol(
 
     int s = 16;
 
+    /* Each probe of the binary search would chain a data-dependent
+     * multiply on the critical path. For the decoder's unsigned values
+     * (low < 2^24, and 0x40 <= range <= 0x3fff from the renormalization
+     * invariant ac->range >= 0x10000),
+     *     low < range * symbols[s].low  <=>  low / range < symbols[s].low
+     * so the quotient, computed once, decides every probe instead. */
+
     if (ac->low < range * symbols[s].low) {
+        unsigned q = ac->low / range;
         s >>= 1;
-        s -= ac->low < range * symbols[s].low ? 4 : -4;
-        s -= ac->low < range * symbols[s].low ? 2 : -2;
-        s -= ac->low < range * symbols[s].low ? 1 : -1;
-        s -= ac->low < range * symbols[s].low;
+        s -= q < symbols[s].low ? 4 : -4;
+        s -= q < symbols[s].low ? 2 : -2;
+        s -= q < symbols[s].low ? 1 : -1;
+        s -= q < symbols[s].low;
     }
 
     ac->low -= range * symbols[s].low;


### PR DESCRIPTION
`lc3_get_symbol()` compares `ac->low` against `range * symbols[s].low` at every probe of its binary search. Each probe's `s` depends on the previous compare, so that is up to five dependent multiplies on the critical path of every decoded symbol.

For unsigned values with `range >= 1`:

```
low < range * L   <=>   low / range < L
```

(let `q = low / range`, so `range*q <= low < range*(q+1)`; if `q < L` then `low < range*(q+1) <= range*L`, and if `low < range*L` then `range*q <= low < range*L`, so `q < L`.)

So one division before the search turns each probe into a plain table compare. `ac->range` is initialized to `0xffffff` and renormalization keeps it `>= 0x10000`, so `range` is in `[0x40, 0x3fff]` and the division is always defined.

**Where it is enabled:** only on cores with a fast hardware divider, via `LC3_FAST_UDIV` in `common.h` (1 on x86-64 / AArch64, 0 otherwise, overridable with `-DLC3_FAST_UDIV=0/1`). MCUs, 32-bit ARM and audio DSPs compile the original multiply-based search unchanged.

**Correctness:** encoded and decoded outputs are byte-identical to the unpatched build (SHA-256 on every artifact) over a deterministic 180 s 48 kHz corpus at 32 and 96 kbps, 7.5 and 10 ms frames, with `LC3_FAST_UDIV` both on and off.

**Performance:** decoder wall time 3–5% faster on Apple M2 Pro (Apple clang 15, release flags), interleaved A/B, median of 6–10 rounds. Encoder and `lc3_put_symbol` untouched.
